### PR TITLE
add test for ome zarr edges

### DIFF
--- a/src/test/java/spimdata/OmeZarrWithWriterTest.java
+++ b/src/test/java/spimdata/OmeZarrWithWriterTest.java
@@ -185,8 +185,8 @@ public class OmeZarrWithWriterTest {
     }
 
     @Test
-    void checkOmeZarrEdges() throws SpimDataException {
-        // check that edges in most downsampled levels are written properly for ome-zarr (i.e. that the loopback
+    void checkOmeZarrLoopBack() throws SpimDataException {
+        // check that most downsampled levels are written properly for ome-zarr (i.e. that the loopback
         // is working correctly)
         // related to https://github.com/mobie/mobie-viewer-fiji/issues/572
 

--- a/src/test/java/spimdata/OmeZarrWithWriterTest.java
+++ b/src/test/java/spimdata/OmeZarrWithWriterTest.java
@@ -1,9 +1,15 @@
 package spimdata;
 
+import bdv.img.cache.VolatileCachedCellImg;
 import ij.IJ;
 import ij.ImagePlus;
+import mpicbg.spim.data.SpimData;
 import mpicbg.spim.data.SpimDataException;
+import mpicbg.spim.data.sequence.MultiResolutionSetupImgLoader;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.cell.CellLocalizingCursor;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.integer.GenericByteType;
 import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.io.SpimDataOpener;
 import org.embl.mobie.io.n5.util.DownsampleBlock;
@@ -28,41 +34,87 @@ public class OmeZarrWithWriterTest {
     private String imageName;
     private AffineTransform3D sourceTransform;
     private File tempDir;
+    private DownsampleBlock.DownsamplingMethod downsamplingMethod;
+    private Compression compression;
 
     @BeforeEach
     void setUp( @TempDir Path tempDir ) throws IOException {
         this.tempDir = tempDir.toFile();
         imageName = "testImage";
         sourceTransform = new AffineTransform3D();
+        downsamplingMethod = DownsampleBlock.DownsamplingMethod.Average;
+        compression = new GzipCompression();
     }
 
-    public static ImagePlus makeImage( String imageName ) {
-        // make an image with random values, same size as the imagej sample head image
-        return IJ.createImage(imageName, "8-bit noise", 186, 226, 27);
+    ImagePlus makeImage( String imageName, int width, int height, int depth ) {
+        // make an image with random values
+        return IJ.createImage(imageName, "8-bit noise", width, height, depth);
     }
 
-    String writeImageAndGetPath( ImageDataFormat imageDataFormat ) {
-        ImagePlus imp = makeImage( imageName );
-        DownsampleBlock.DownsamplingMethod downsamplingMethod = DownsampleBlock.DownsamplingMethod.Average;
-        Compression compression = new GzipCompression();
+    String getXmlPath() {
+        return new File(tempDir, imageName + ".xml").getAbsolutePath();
+    }
+
+    String getZarrPath() {
+        return new File(tempDir, imageName + ".ome.zarr").getAbsolutePath();
+    }
+
+
+    String writeImageAndGetPath( ImagePlus imp, ImageDataFormat imageDataFormat,
+                                 int[][] resolutions, int[][] subdivisions ) {
         String filePath;
 
         // gzip compression by default
         switch( imageDataFormat ) {
             case BdvN5:
-                filePath = new File(tempDir, imageName + ".xml").getAbsolutePath();
+                filePath = getXmlPath();
+                new WriteImgPlusToN5().export( imp, resolutions, subdivisions, filePath,
+                    sourceTransform, downsamplingMethod, compression, new String[]{imageName} );
+                break;
+
+            case BdvOmeZarr:
+                filePath = getXmlPath();
+                new WriteImgPlusToN5BdvOmeZarr().export( imp, resolutions, subdivisions, filePath,
+                        sourceTransform, downsamplingMethod, compression, new String[]{imageName} );
+                break;
+
+            case OmeZarr:
+                filePath = getZarrPath();
+                new WriteImgPlusToN5OmeZarr().export( imp, resolutions, subdivisions, filePath,
+                        sourceTransform, downsamplingMethod, compression, new String[]{imageName} );
+                break;
+
+            default:
+                throw new UnsupportedOperationException();
+
+        }
+
+        return filePath;
+    }
+
+    String writeImageAndGetPath( ImageDataFormat imageDataFormat ) {
+
+        // make an image with random values, same size as the imagej sample head image
+        ImagePlus imp = makeImage( imageName, 186, 226, 27 );
+
+        String filePath;
+
+        // gzip compression by default
+        switch( imageDataFormat ) {
+            case BdvN5:
+                filePath = getXmlPath();
                 new WriteImgPlusToN5().export(imp, filePath, sourceTransform, downsamplingMethod,
                         compression, new String[]{imageName} );
                 break;
 
             case BdvOmeZarr:
-                filePath = new File(tempDir, imageName + ".xml").getAbsolutePath();
+                filePath = getXmlPath();
                 new WriteImgPlusToN5BdvOmeZarr().export(imp, filePath, sourceTransform,
                         downsamplingMethod, compression, new String[]{imageName} );
                 break;
 
             case OmeZarr:
-                filePath = new File(tempDir, imageName + ".ome.zarr").getAbsolutePath();
+                filePath = getZarrPath();
                 new WriteImgPlusToN5OmeZarr().export(imp, filePath, sourceTransform,
                         downsamplingMethod, compression, new String[]{imageName});
                 break;
@@ -73,6 +125,34 @@ public class OmeZarrWithWriterTest {
         }
 
         return filePath;
+    }
+
+    VolatileCachedCellImg getImage(SpimData spimData, int setupId, int timepoint, int level ) {
+        MultiResolutionSetupImgLoader<?> imageLoader = (MultiResolutionSetupImgLoader<?>) spimData.
+                getSequenceDescription().getImgLoader().getSetupImgLoader( setupId );
+
+        return (VolatileCachedCellImg) imageLoader.getImage( timepoint, level );
+    }
+
+     boolean  isImageIdentical( VolatileCachedCellImg image1, VolatileCachedCellImg image2 ) {
+
+        boolean isIdentical = true;
+
+        CellLocalizingCursor cursorInput = image1.localizingCursor();
+        RandomAccess randomAccessImage2 = image2.randomAccess();
+
+        while ( cursorInput.hasNext()) {
+            cursorInput.fwd();
+
+            GenericByteType image1Value = (GenericByteType) cursorInput.get();
+            GenericByteType image2Value = (GenericByteType) randomAccessImage2.setPositionAndGet( cursorInput );
+
+            if ( !image1Value.equals(image2Value) ) {
+                isIdentical = false;
+                break;
+            }
+        }
+        return isIdentical;
     }
 
     @Test
@@ -102,5 +182,32 @@ public class OmeZarrWithWriterTest {
         assertTrue( new File(removeExtension(xmlPath) + ".ome.zarr").exists() );
 
         new SpimDataOpener().openSpimData( xmlPath, format );
+    }
+
+    @Test
+    void checkOmeZarrEdges() throws SpimDataException {
+        // check that edges in most downsampled levels are written properly for ome-zarr (i.e. that the loopback
+        // is working correctly)
+        // related to https://github.com/mobie/mobie-viewer-fiji/issues/572
+
+        // use resolutions / subdivisions that trigger 'loopback' i.e. reading from previously downsampled levels
+        // rather than the original image
+        int[][] resolutions = new int[][]{ {1, 1, 1}, {2, 2, 2}, {4, 4, 4} };
+        int[][] subdivisions = new int[][]{ {64, 64, 64}, {64, 64, 64}, {64, 64, 64} };
+        int lowestResolutionLevel = 2;
+        ImagePlus imp = makeImage( imageName, 400, 400, 400);
+
+        String zarrPath = writeImageAndGetPath( imp, ImageDataFormat.OmeZarr, resolutions, subdivisions );
+        String n5Path = writeImageAndGetPath(imp, ImageDataFormat.BdvN5, resolutions, subdivisions );
+
+        SpimDataOpener spimDataOpener = new SpimDataOpener();
+        SpimData spimDataZarr = (SpimData) spimDataOpener.openSpimData( zarrPath, ImageDataFormat.OmeZarr );
+        SpimData spimDataN5 = (SpimData) spimDataOpener.openSpimData( n5Path, ImageDataFormat.BdvN5 );
+
+        VolatileCachedCellImg lowestResN5 = getImage( spimDataN5, 0, 0, lowestResolutionLevel );
+        VolatileCachedCellImg lowestResZarr = getImage( spimDataZarr, 0, 0, lowestResolutionLevel );
+
+        // check lowest resolution level of n5 and ome-zarr have identical pixel values
+        assertTrue( isImageIdentical( lowestResN5, lowestResZarr ) );
     }
 }


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-io/issues/56

Adds a test for the ome-zarr edges issue.
This writes an image that triggers 'loopBack' as ome-zarr and n5, and checks that the written lowest resolution level is identical between the two. I checked, and this test fails without the fixes I added in the last PR - so it's working :)