### PR TITLE
Add patches for OmeZarrImageLoader

### DIFF
--- a/src/main/java/org/embl/mobie/io/ome/zarr/loaders/N5OMEZarrImageLoader.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/loaders/N5OMEZarrImageLoader.java
@@ -107,6 +107,15 @@ public class N5OMEZarrImageLoader implements ViewerImgLoader, MultiResolutionImg
     public N5OMEZarrImageLoader(N5Reader n5Reader, AbstractSequenceDescription<?, ?, ?> sequenceDescription) {
         this.n5 = n5Reader;
         this.seq = sequenceDescription; // TODO: it is better to fetch from within Zarr
+		try
+		{
+			initSetups();
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+			throw new RuntimeException(e);
+		}
     }
 
     public N5OMEZarrImageLoader(N5Reader n5Reader) {

--- a/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlIoN5S3ZarrImageLoader.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlIoN5S3ZarrImageLoader.java
@@ -54,10 +54,10 @@ public class XmlIoN5S3ZarrImageLoader implements XmlIoBasicImgLoader<N5S3OMEZarr
         final Element elem = new Element("ImageLoader");
         elem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME, "ome.n5.zarr.s3");
         elem.setAttribute("version", "1.0");
-        elem.setAttribute(SERVICE_ENDPOINT, imgLoader.getServiceEndpoint());
-        elem.setAttribute(SIGNING_REGION, imgLoader.getSigningRegion());
-        elem.setAttribute(BUCKET_NAME, imgLoader.getBucketName());
-        elem.setAttribute(KEY, imgLoader.getKey());
+		elem.addContent(XmlHelpers.textElement(SERVICE_ENDPOINT, imgLoader.getServiceEndpoint()));
+		elem.addContent(XmlHelpers.textElement(SIGNING_REGION, imgLoader.getSigningRegion()));
+		elem.addContent(XmlHelpers.textElement(BUCKET_NAME, imgLoader.getBucketName()));
+		elem.addContent(XmlHelpers.textElement(KEY, imgLoader.getKey()));
 
         return elem;
     }

--- a/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlN5S3OmeZarrImageLoader.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlN5S3OmeZarrImageLoader.java
@@ -1,5 +1,6 @@
 package org.embl.mobie.io.ome.zarr.loaders.xml;
 
+import mpicbg.spim.data.XmlHelpers;
 import mpicbg.spim.data.generic.sequence.AbstractSequenceDescription;
 import mpicbg.spim.data.generic.sequence.ImgLoaderIo;
 import mpicbg.spim.data.generic.sequence.XmlIoBasicImgLoader;
@@ -7,6 +8,7 @@ import org.embl.mobie.io.ome.zarr.loaders.N5S3OMEZarrImageLoader;
 import org.jdom2.Element;
 
 import java.io.File;
+import java.io.IOException;
 
 import static mpicbg.spim.data.XmlKeys.IMGLOADER_FORMAT_ATTRIBUTE_NAME;
 
@@ -22,7 +24,11 @@ public class XmlN5S3OmeZarrImageLoader implements XmlIoBasicImgLoader<N5S3OMEZar
         final Element elem = new Element("ImageLoader");
         elem.setAttribute(IMGLOADER_FORMAT_ATTRIBUTE_NAME, "bdv.ome.zarr.s3");
         elem.setAttribute("version", "0.2");
-        return elem;
+		elem.addContent(XmlHelpers.textElement(SERVICE_ENDPOINT, imgLoader.getServiceEndpoint()));
+		elem.addContent(XmlHelpers.textElement(SIGNING_REGION, imgLoader.getSigningRegion()));
+		elem.addContent(XmlHelpers.textElement(BUCKET_NAME, imgLoader.getBucketName()));
+		elem.addContent(XmlHelpers.textElement(KEY, imgLoader.getKey()));
+		return elem;
     }
 
     public Element toXml(String serviceEndpoint, String signingRegion, String bucketName, String key) {
@@ -38,6 +44,17 @@ public class XmlN5S3OmeZarrImageLoader implements XmlIoBasicImgLoader<N5S3OMEZar
 
     @Override
     public N5S3OMEZarrImageLoader fromXml(Element elem, File basePath, AbstractSequenceDescription<?, ?, ?> sequenceDescription) {
-        return null;
-    }
+		final String serviceEndpoint = XmlHelpers.getText(elem, SERVICE_ENDPOINT);
+		final String signingRegion = XmlHelpers.getText(elem, SIGNING_REGION);
+		final String bucketName = XmlHelpers.getText( elem, BUCKET_NAME);
+		final String key = XmlHelpers.getText(elem, KEY);
+		try
+		{
+			return new N5S3OMEZarrImageLoader(serviceEndpoint, signingRegion, bucketName, key, "/", sequenceDescription);
+		}
+		catch (IOException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
 }


### PR DESCRIPTION
- add patches for unimplemented parts in [XmlN5S3OmeZarrImageLoader](https://github.com/elephant-track/mobie-io/blob/b0ebbab7b201d984848d93e6e974f64ec1835727/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlN5S3OmeZarrImageLoader.java)
- move `ServiceEndpoint`, `SigningRegion`, `BucketName` and `Key` from attributes to contents in [XmlIoN5S3ZarrImageLoader.toXml()](https://github.com/elephant-track/mobie-io/blob/b0ebbab7b201d984848d93e6e974f64ec1835727/src/main/java/org/embl/mobie/io/ome/zarr/loaders/xml/XmlIoN5S3ZarrImageLoader.java)
- call `initSetups()` in a deprecated constructor of [N5OMEZarrImageLoader](https://github.com/elephant-track/mobie-io/blob/b0ebbab7b201d984848d93e6e974f64ec1835727/src/main/java/org/embl/mobie/io/ome/zarr/loaders/N5OMEZarrImageLoader.java) to avoid an error in loading from xml