### PR TITLE
Write correct OME-ZARR units

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.embl.mobie</groupId>
     <artifactId>mobie-io</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
 
     <url>https://github.com/mobie/mobie-io</url>
     <name>BDV ImageLoaders</name>

--- a/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
@@ -3,6 +3,8 @@ package org.embl.mobie.io.ome.zarr.util;
 import lombok.extern.slf4j.Slf4j;
 import ucar.units.*;
 
+import java.nio.charset.StandardCharsets;
+
 @Slf4j
 public enum UnitTypes {
     ANGSTROM("angstrom"),
@@ -73,7 +75,7 @@ public enum UnitTypes {
 
     public static UnitTypes convertUnit(String unit) {
         // Convert the mu symbol into "u".
-        String unitString = unit.replace("\\u00B5", "u");
+        String unitString = unit.replace("\u00B5", "u");
 
         try {
             UnitFormat unitFormatter = UnitFormatManager.instance();

--- a/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
@@ -3,8 +3,6 @@ package org.embl.mobie.io.ome.zarr.util;
 import lombok.extern.slf4j.Slf4j;
 import ucar.units.*;
 
-import java.nio.charset.StandardCharsets;
-
 @Slf4j
 public enum UnitTypes {
     ANGSTROM("angstrom"),

--- a/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/util/UnitTypes.java
@@ -1,5 +1,9 @@
 package org.embl.mobie.io.ome.zarr.util;
 
+import lombok.extern.slf4j.Slf4j;
+import ucar.units.*;
+
+@Slf4j
 public enum UnitTypes {
     ANGSTROM("angstrom"),
     ATTOMETER("attometer"),
@@ -65,6 +69,29 @@ public enum UnitTypes {
             }
         }
         return false;
+    }
+
+    public static UnitTypes convertUnit(String unit) {
+        // Convert the mu symbol into "u".
+        String unitString = unit.replace("\\u00B5", "u");
+
+        try {
+            UnitFormat unitFormatter = UnitFormatManager.instance();
+            Unit inputUnit = unitFormatter.parse(unitString);
+
+            for (UnitTypes unitType: UnitTypes.values()) {
+                Unit zarrUnit = unitFormatter.parse(unitType.typeName);
+                if (zarrUnit.getCanonicalString().equals(inputUnit.getCanonicalString())) {
+                    log.info("Converted unit: " + unit + " to recommended ome-zarr unit: " + unitType.getTypeName());
+                    return unitType;
+                }
+            }
+        } catch (SpecificationException | UnitDBException | PrefixDBException | UnitSystemException e) {
+            e.printStackTrace();
+        }
+
+        log.warn(unit + " is not one of the recommended units for ome-zarr");
+        return null;
     }
 
     public String getTypeName() {

--- a/src/main/java/org/embl/mobie/io/ome/zarr/util/ZarrAxes.java
+++ b/src/main/java/org/embl/mobie/io/ome/zarr/util/ZarrAxes.java
@@ -49,15 +49,30 @@ public enum ZarrAxes {
     public List<ZarrAxis> toAxesList( String spaceUnit, String timeUnit ) {
         List<ZarrAxis> zarrAxesList = new ArrayList<>();
         List<String> zarrAxesStrings = getAxesList();
+
+        String[] units = new String[]{spaceUnit, timeUnit};
+
+        // convert to valid ome-zarr units, if possible, otherwise just go ahead with
+        // given unit
+        for ( int i = 0; i< units.length; i++ ) {
+            String unit = units[i];
+            if ( !UnitTypes.contains(unit) ) {
+                UnitTypes unitType = UnitTypes.convertUnit(unit);
+                if (unitType != null) {
+                    units[i] = unitType.getTypeName();
+                }
+            }
+        }
+
         for ( int i = 0; i<zarrAxesStrings.size(); i++  ) {
             String axisString = zarrAxesStrings.get(i);
             AxesTypes axisType =  AxesTypes.getAxisType( axisString );
 
             String unit;
             if ( axisType == AxesTypes.SPACE ) {
-                unit = spaceUnit;
+                unit = units[0];
             } else if ( axisType == AxesTypes.TIME ) {
-                unit = timeUnit;
+                unit = units[1];
             } else {
                 unit = null;
             }

--- a/src/test/java/spimdata/OmeZarrV4S3SpimDataTests.java
+++ b/src/test/java/spimdata/OmeZarrV4S3SpimDataTests.java
@@ -1,0 +1,24 @@
+package spimdata;
+
+import mpicbg.spim.data.SpimData;
+import org.embl.mobie.io.ome.zarr.openers.OMEZarrS3Opener;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OmeZarrV4S3SpimDataTests {
+    public static final String ZYX_FILE_KEY = "https://s3.embl.de/i2k-2020/ngff-example-data/v0.4/zyx.ome.zarr";
+
+    @Test
+    public void SpimDataV4UnitTest() throws IOException {
+        SpimData spimData = OMEZarrS3Opener.readURL(ZYX_FILE_KEY);
+
+        final String unit = spimData.getSequenceDescription().getViewSetupsOrdered().get( 0 ).getVoxelSize().unit();
+        final double[] voxelSize = spimData.getSequenceDescription().getViewSetupsOrdered().get( 0 ).getVoxelSize().dimensionsAsDoubleArray();
+
+        assertEquals("nanometer", unit);
+        assertArrayEquals( voxelSize, new double[]{64.0, 64.0, 64.0});
+    }
+}


### PR DESCRIPTION
fixes https://github.com/mobie/mobie-io/issues/74 and https://github.com/mobie/mobie-io/issues/82

Main changes:
- when converting imageplus to OME-ZARR, units are converted to the recommended unit for ome-zarr (if possible).
- voxelDimensions are populated from N5OmeZarrImageLoader
- test added for units / dimensions (as in https://github.com/mobie/mobie-io/issues/82)