### PR TITLE
Add spatial transcriptomics data test

### DIFF
--- a/src/test/java/projects/ngff/v04/SpatialTranscriptomicsDataNgffTest.java
+++ b/src/test/java/projects/ngff/v04/SpatialTranscriptomicsDataNgffTest.java
@@ -1,0 +1,99 @@
+package projects.ngff.v04;
+
+import org.embl.mobie.io.ImageDataFormat;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import bdv.img.cache.VolatileCachedCellImg;
+import lombok.extern.slf4j.Slf4j;
+import mpicbg.spim.data.SpimDataException;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.cell.CellGrid;
+//import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import projects.remote.BaseTest;
+
+/*
+ * Extra test for the data from 
+ * https://s3.embl.de/i2k-2020/spatial-transcriptomics-example/pos42/images/ome-zarr/MMStack_Pos42.ome.zarr
+ * which is for some reason not displayed properly in MoBIE / BDV.
+ * See https://github.com/mobie/mobie-viewer-fiji/issues/791 for details.
+*/
+
+@Slf4j
+public class SpatialTranscriptomicsDataNgffTest extends BaseTest {
+    private static final String URL = "https://s3.embl.de/i2k-2020/spatial-transcriptomics-example/pos42/images/ome-zarr/MMStack_Pos42.ome.zarr";
+    private static final ImageDataFormat FORMAT = ImageDataFormat.OmeZarrS3;
+
+    public SpatialTranscriptomicsDataNgffTest() throws SpimDataException {
+        super(URL, FORMAT);
+        //set values for base test
+        setExpectedTimePoints(1);
+        setExpectedChannelsNumber(4);
+        setExpectedShape(new FinalDimensions(2048, 2048, 6, 4));
+        setExpectedDType("uint16");
+    }
+
+    @Test
+    public void checkDataset() {
+        long x = 1;
+        long y = 1;
+        long z = 1;
+        long[] imageDimensions = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0).dimensionsAsLongArray();
+        if (x > imageDimensions[0] || y > imageDimensions[1] || z > imageDimensions[2]) {
+            throw new RuntimeException("Coordinates out of bounds");
+        }
+
+        RandomAccessibleInterval<?> randomAccessibleInterval = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0);
+        VolatileCachedCellImg volatileCachedCellImg = (VolatileCachedCellImg) randomAccessibleInterval;
+        CellGrid cellGrid = volatileCachedCellImg.getCellGrid();
+        long[] dims = new long[]{2048, 2048, 6};
+        int[] cellDims = new int[]{512, 512, 1};
+        CellGrid expected = new CellGrid(dims, cellDims);
+        Assertions.assertEquals(expected, cellGrid);
+    }
+    
+    @Test
+    public void checkImgValue() {
+
+        // random test data generated independently with python
+        //(0, 992, 397, 4) : 170
+        RandomAccessibleInterval<?> randomAccessibleInterval = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(0).getImage(0);
+        // ShortType o = (ShortType) randomAccessibleInterval.getAt(992, 397, 4);
+        UnsignedShortType o = (UnsignedShortType) randomAccessibleInterval.getAt(992, 397, 4);
+        int value = o.get();
+        int expectedValue = 170;
+        Assertions.assertEquals(expectedValue, value);
+        
+        //(1, 92, 762, 5) : 163
+        randomAccessibleInterval = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(1).getImage(0);
+        // o = (ShortType) randomAccessibleInterval.getAt(92, 762, 5);
+        o = (UnsignedShortType) randomAccessibleInterval.getAt(92, 762, 5);
+        value = o.get();
+        expectedValue = 163;
+        Assertions.assertEquals(expectedValue, value);
+        
+        //(1, 405, 1294, 4) : 186
+        // o = (ShortType) randomAccessibleInterval.getAt(405, 1294, 4);
+        o = (UnsignedShortType) randomAccessibleInterval.getAt(405, 1294, 4);
+        value = o.get();
+        expectedValue = 186;
+        Assertions.assertEquals(expectedValue, value);
+        
+        //(1, 737, 900, 3) : 177
+        // o = (ShortType) randomAccessibleInterval.getAt(737, 900, 3);
+        o = (UnsignedShortType) randomAccessibleInterval.getAt(737, 900, 3);
+        value = o.get();
+        expectedValue = 177;
+        Assertions.assertEquals(expectedValue, value);
+        
+        //(3, 520, 269, 3) : 1143
+        randomAccessibleInterval = spimData.getSequenceDescription().getImgLoader().getSetupImgLoader(3).getImage(0);
+        // o = (ShortType) randomAccessibleInterval.getAt(520, 269, 3);
+        o = (UnsignedShortType) randomAccessibleInterval.getAt(520, 269, 3);
+        value = o.get();
+        expectedValue = 1143;
+        Assertions.assertEquals(expectedValue, value);
+    }
+}


### PR DESCRIPTION
The test is currently failing (all values are returned as 0), which is consistent with the behavior in the viewer (see https://github.com/mobie/mobie-viewer-fiji/issues/791).

I have a theory now why this is:
Usually we have the following layout: 
```
$ mc ls embl/i2k-2020/ngff-example-data/v0.4/czyx.ome.zarr
[2022-06-21 20:49:37 CEST] 2.3KiB STANDARD .zattrs
[2022-06-21 20:49:37 CEST]    24B STANDARD .zgroup
[2022-09-09 00:23:19 CEST]     0B s0/
[2022-09-09 00:23:19 CEST]     0B s1/
[2022-09-09 00:23:19 CEST]     0B s2/
```

However, this ome.zarr file has the layout:
```
$ mc ls embl/i2k-2020/spatial-transcriptomics-example/pos42/images/ome-zarr/MMStack_Pos42.ome.zarr
[2022-07-26 15:19:21 CEST] 3.0KiB STANDARD .zattrs
[2022-07-26 15:19:21 CEST]    24B STANDARD .zgroup
[2022-09-09 00:27:47 CEST]     0B 0/
[2022-09-09 00:27:47 CEST]     0B 1/
[2022-09-09 00:27:47 CEST]     0B 2/
[2022-09-09 00:27:47 CEST]     0B 3/
[2022-09-09 00:27:47 CEST]     0B 4/
[2022-09-09 00:27:47 CEST]     0B labels/
```

I.e. instead of being stored as `s0`, ... the scale level arrays are stored as `0`, ...

So my guess is that we somewhere hard-code the `s0`, ... layout when looking for chunks instead of taking the correct values from the multiscales metadata.