### PR TITLE
N5 3.0.0 hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,10 +120,39 @@
                 <configuration>
                     <excludes>
                         <exclude>${someModule.test.excludes}</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.janelia.saalfeldlab:n5*</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.janelia.saalfeldlab.n5</pattern>
+									<shadedPattern>org.embl.mobie.io.n5.shaded</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>net.imglib2.realtransform</pattern>
+									<shadedPattern>org.embl.mobie.io.n5.shaded</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
     </build>
 
     <repositories>

--- a/src/test/java/dataformats/local/BaseLocalTest.java
+++ b/src/test/java/dataformats/local/BaseLocalTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.embl.mobie.io.SpimDataOpener;

--- a/src/test/java/dataformats/local/ConstantinNoTablesTest.java
+++ b/src/test/java/dataformats/local/ConstantinNoTablesTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/CovidEMCFTest.java
+++ b/src/test/java/dataformats/local/CovidEMCFTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/CovidEmDatasetsTest.java
+++ b/src/test/java/dataformats/local/CovidEmDatasetsTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/CovidPlateTest.java
+++ b/src/test/java/dataformats/local/CovidPlateTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/CovidTomosTest.java
+++ b/src/test/java/dataformats/local/CovidTomosTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/GiuliaMartinCLEMTest.java
+++ b/src/test/java/dataformats/local/GiuliaMartinCLEMTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/JulianNoTablesTest.java
+++ b/src/test/java/dataformats/local/JulianNoTablesTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 
 import org.embl.mobie.io.ImageDataFormat;

--- a/src/test/java/dataformats/local/MartinFloatTest.java
+++ b/src/test/java/dataformats/local/MartinFloatTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/OmeNgffPrototypesTest.java
+++ b/src/test/java/dataformats/local/OmeNgffPrototypesTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/OmeZarrTest.java
+++ b/src/test/java/dataformats/local/OmeZarrTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/PlanktonTest.java
+++ b/src/test/java/dataformats/local/PlanktonTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/PlatynereisTest.java
+++ b/src/test/java/dataformats/local/PlatynereisTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Assertions;
 import mpicbg.spim.data.SpimDataException;
 
 
-public class PlatynereisTest extends projects.local.BaseLocalTest
+public class PlatynereisTest extends dataformats.local.BaseLocalTest
 {
     private static final String PATH = "/g/arendt/EM_6dpf_segmentation/platy-browser-data/data/";
     private static final ImageDataFormat FORMAT = ImageDataFormat.BdvN5;

--- a/src/test/java/dataformats/local/TestDataTest.java
+++ b/src/test/java/dataformats/local/TestDataTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;

--- a/src/test/java/dataformats/local/TobiasTest.java
+++ b/src/test/java/dataformats/local/TobiasTest.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package projects.local;
+package dataformats.local;
 
 import org.embl.mobie.io.ImageDataFormat;
 import org.junit.Test;


### PR DESCRIPTION
This could work as a temporary hot-fix for distributing mobie-io together with the updated n5-3.0.0 library and dependents in Fiji.  Instead of fixing mobie-io, which will require some work to remove all the code duplication and
some conceptual simplifications, mobie-io includes n5-2.5.1, n5-aws-s3-3.2.0, n5-blosc-1.1.0, n5-hdf5-1.4.2, n5-ij-3.2.3, n5-imglib2-5.0.0 re-packaged under org.embl.mobie.io.n5.shaded (and some leftover resources in the root path?).

Dependents of this mobie-io hotfix will have to acknowledge that they are not using the official n5 artifacts and import the org.embl.mobie.io.n5.shaded where they reference them.