### PR TITLE
Increase n5 universe version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <n5-google-cloud.version>4.1.0</n5-google-cloud.version>
         <n5-zarr.version>1.3.1</n5-zarr.version>
         <n5-ij.version>4.1.1</n5-ij.version>
-        <n5-universe.version>1.4.1</n5-universe.version>
+        <n5-universe.version>1.4.3-SNAPSHOT</n5-universe.version>
         <n5-aws-s3.version>4.1.1</n5-aws-s3.version>
         <bigdataviewer-core.version>10.4.13</bigdataviewer-core.version>
         <bigdataviewer-vistools.version>1.0.0-beta-34</bigdataviewer-vistools.version>

--- a/src/test/java/org/embl/mobie/io/OMEZarrWriterTest.java
+++ b/src/test/java/org/embl/mobie/io/OMEZarrWriterTest.java
@@ -4,21 +4,25 @@ import ij.IJ;
 import ij.ImagePlus;
 import org.embl.mobie.io.imagedata.ImageData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class OMEZarrWriterTest
 {
     @Test
-    public void writeAndReadOMEZarr()
+    public void writeAndReadOMEZarr(@TempDir Path tempDir)
     {
         ImagePlus imp = IJ.createImage( "test", "8-bit ramp", 186, 226, 27 );
 
-        String uri = "src/test/tmp/test.zarr";
+        String uri = tempDir.resolve("test.zarr").toString();
 
         OMEZarrWriter.write( imp,
                 uri,
                 OMEZarrWriter.ImageType.Intensities,
-                true );
+                false );
 
         ImageData< ? > imageData = ImageDataOpener.open( uri );
 


### PR DESCRIPTION
This PR increases the n5 universe version (including fix for windows) and changes the ome-zarr test to not use `ovewrite=True`